### PR TITLE
A few minor improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.9-slim-buster
 ARG VERSION
 
 RUN apt-get update \
-&&  apt-get install -y git build-essential \
+&&  apt-get install -y build-essential \
 && curl -L https://github.com/lnbits/lnbits/archive/$VERSION.tar.gz | tar -xz --strip-components=1
 
 WORKDIR /lnbits

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,9 @@ FROM python:3.9-slim-buster
 
 ARG VERSION
 
-WORKDIR /
-
 RUN apt-get update \
-&&  apt-get install -y git build-essential gcc make \
-&&  git clone --branch $VERSION https://github.com/lnbits/lnbits.git 
+&&  apt-get install -y git build-essential \
+&& curl -L https://github.com/lnbits/lnbits/archive/$VERSION.tar.gz | tar -xz --strip-components=1
 
 WORKDIR /lnbits
 


### PR DESCRIPTION
- Workdir doesn't need to be set before `apt` is run, it works everywhere.
- Download lnbits without git
- Remove make and gcc from the install command, build-essential installs it anyway